### PR TITLE
Amir/rudderstack initialize with key from the value given in arg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deriv/analytics",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "The analytics package contains all the utility functions used for tracking user events and sending them to the respective platform such as Rudderstack.",
   "keywords": [
     "rudderstack",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deriv/analytics",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "The analytics package contains all the utility functions used for tracking user events and sending them to the respective platform such as Rudderstack.",
   "keywords": [
     "rudderstack",

--- a/src/rudderstack.ts
+++ b/src/rudderstack.ts
@@ -136,7 +136,9 @@ export class RudderStack {
    * For production environment, ensure that `RUDDERSTACK_PRODUCTION_KEY` and `RUDDERSTACK_URL` is set.
    */
   init() {
-    const is_production = process.env.CIRCLE_JOB === "release_production";
+    const is_production =
+      process.env.CIRCLE_JOB === "release_production" ||
+      !!process.env.GATSBY_RUDDERSTACK_PRODUCTION_KEY;
 
     const RUDDERSTACK_KEY = is_production
       ? process.env.RUDDERSTACK_PRODUCTION_KEY ||

--- a/src/rudderstack.ts
+++ b/src/rudderstack.ts
@@ -95,12 +95,18 @@ export type IdentifyAction = {
   language: string;
 };
 
+export type ExperimentViewedEvent = {
+  experimentId: string;
+  variationId: string | number;
+};
+
 export type TEvents = {
   ce_virtual_signup_form: VirtualSignupFormAction;
   ce_real_account_signup_form: RealAccountSignupFormAction;
   ce_virtual_signup_email_confirmation: VirtualSignupEmailConfirmationAction;
   ce_trade_types_form: TradeTypesFormAction;
   identify: IdentifyAction;
+  experiment_viewed: ExperimentViewedEvent;
 };
 
 export type TTrackOptions = {

--- a/src/rudderstack.ts
+++ b/src/rudderstack.ts
@@ -113,14 +113,15 @@ export type TTrackOptions = {
   is_anonymous: boolean;
 };
 
+export type TInitParams = {
+  rudderstack_key: string;
+  rudderstack_url: string;
+};
+
 export class RudderStack {
   has_identified = false;
   has_initialized = false;
   current_page = "";
-
-  constructor() {
-    this.init();
-  }
 
   /**
    * @returns The anonymous ID assigned to the user before the identify event was called
@@ -137,28 +138,16 @@ export class RudderStack {
   }
 
   /**
-   * Initializes the Rudderstack SDK. Ensure that the appropriate environment variables are set before this is called.
-   * For local/staging environment, ensure that `RUDDERSTACK_STAGING_KEY` and `RUDDERSTACK_URL` is set.
-   * For production environment, ensure that `RUDDERSTACK_PRODUCTION_KEY` and `RUDDERSTACK_URL` is set.
+   * Initializes the Rudderstack SDK. Ensure that the appropriate values of the Rudderstack key and URL are passed.
    */
-  init() {
-    const is_production =
-      process.env.CIRCLE_JOB === "release_production" ||
-      !!process.env.GATSBY_RUDDERSTACK_PRODUCTION_KEY;
-
-    const RUDDERSTACK_KEY = is_production
-      ? process.env.RUDDERSTACK_PRODUCTION_KEY ||
-        process.env.GATSBY_RUDDERSTACK_PRODUCTION_KEY
-      : process.env.RUDDERSTACK_STAGING_KEY ||
-        process.env.GATSBY_RUDDERSTACK_STAGING_KEY;
-    const RUDDERSTACK_URL =
-      process.env.RUDDERSTACK_URL || process.env.GATSBY_RUDDERSTACK_URL;
-
-    if (RUDDERSTACK_KEY && RUDDERSTACK_URL) {
-      RudderAnalytics.load(RUDDERSTACK_KEY, RUDDERSTACK_URL);
+  init({ rudderstack_key, rudderstack_url }: TInitParams) {
+    if (rudderstack_key && rudderstack_url) {
+      RudderAnalytics.load(rudderstack_key, rudderstack_url);
       RudderAnalytics.ready(() => {
         this.has_initialized = true;
       });
+    } else {
+      console.error('Please provide "rudderstack_key" and "rudderstack_url"');
     }
   }
 


### PR DESCRIPTION
## Important !
> This PR requires changes in both `deriv.com` and `deriv-app` because right now rudderstack is getting initialized automatically once we import it anywhere and it takes the `KEY` and `URL` values from environment variable which is not a good approach (this is currently bouding the library to be used with only deriv.com and deriv-app, see the code below to get the idea)
```js
    const is_production =
      process.env.CIRCLE_JOB === "release_production" ||
      !!process.env.GATSBY_RUDDERSTACK_PRODUCTION_KEY;

    const RUDDERSTACK_KEY = is_production
      ? process.env.RUDDERSTACK_PRODUCTION_KEY ||
        process.env.GATSBY_RUDDERSTACK_PRODUCTION_KEY
      : process.env.RUDDERSTACK_STAGING_KEY ||
        process.env.GATSBY_RUDDERSTACK_STAGING_KEY;
    const RUDDERSTACK_URL =
      process.env.RUDDERSTACK_URL || process.env.GATSBY_RUDDERSTACK_URL;

    if (RUDDERSTACK_KEY && RUDDERSTACK_URL) {
      RudderAnalytics.load(RUDDERSTACK_KEY, RUDDERSTACK_URL);
      RudderAnalytics.ready(() => {
        this.has_initialized = true;
      });
    }
```
This PR is removing these conditions and dropping the current usage of initializing the rudderstack instance inside the library's module, instead we will initialize in the app we want to use. That way it will not be dependant on some shady environment variable setup which the consumer is not aware of.