### PR TITLE
Amir/add types for traders hub form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deriv/analytics",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "The analytics package contains all the utility functions used for tracking user events and sending them to the respective platform such as Rudderstack.",
   "keywords": [
     "rudderstack",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deriv/analytics",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "The analytics package contains all the utility functions used for tracking user events and sending them to the respective platform such as Rudderstack.",
   "keywords": [
     "rudderstack",

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -32,6 +32,8 @@ export function createAnalyticsInstance(options?: Options) {
         user_id,
         app_id,
     }: TCoreAttributes) => {
+        if (!_growthbook && !_rudderstack) return
+
         const user_identity = user_id ? user_id : getId()
 
         // Check if we have Growthbook instance
@@ -54,10 +56,10 @@ export function createAnalyticsInstance(options?: Options) {
         }
     }
 
-    const getFeatureState = (id: string) => _growthbook.getFeatureState(id)?.experimentResult?.name
-    const getFeatureValue = (id: string, defaultValue: string) => _growthbook.getFeatureValue(id, defaultValue)
-    const setUrl = (href: string) => _growthbook.setUrl(href)
-    const getId = () => _rudderstack?.getUserId() || _rudderstack.getAnonymousId()
+    const getFeatureState = (id: string) => _growthbook?.getFeatureState(id)?.experimentResult?.name
+    const getFeatureValue = (id: string, defaultValue: string) => _growthbook?.getFeatureValue(id, defaultValue)
+    const setUrl = (href: string) => _growthbook?.setUrl(href)
+    const getId = () => _rudderstack?.getUserId() || _rudderstack?.getAnonymousId()
 
     /**
      * Pushes page view event to Rudderstack
@@ -65,20 +67,26 @@ export function createAnalyticsInstance(options?: Options) {
      * @param curret_page The name or URL of the current page to track the page view event
      */
     const pageView = (current_page: string, platform = 'Deriv App') => {
+        if (!_rudderstack) return
+
         _rudderstack?.pageView(current_page, platform)
     }
 
     const identifyEvent = () => {
-        if (coreData?.user_identity) {
+        if (coreData?.user_identity && _rudderstack) {
             _rudderstack?.identifyEvent(coreData?.user_identity, { language: coreData?.user_language || 'en' })
         }
     }
 
     const reset = () => {
+        if (!_rudderstack) return
+
         _rudderstack?.reset()
     }
 
     const trackEvent = <T extends keyof TEvents>(event: T, analyticsData: TEvents[T]) => {
+        if (!_rudderstack) return
+
         _rudderstack?.track(event, { ...coreData, ...analyticsData })
     }
     const getInstances = () => ({ ab: _growthbook, tracking: _rudderstack })

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,16 @@ type VirtualSignupEmailConfirmation = {
     email_md5?: string
     error_message?: string
 }
+
+type TradersHubOnboardingFormAction = {
+    action: 'open' | 'close' | 'step_passed' | 'step_back' | 'choose_step_navigation'
+    form_source: 'tradershub_dashboard_form' | 'tradershub_first_entrance' | '7_step'
+    step_num?: number
+    step_codename?: string
+    account_type: string | null
+    device_type: string
+}
+
 type TradeTypesForm = {
     action?: 'open' | 'close' | 'choose_trade_type' | 'search' | 'info_open' | 'info_switcher' | 'info_close'
     trade_type_name?: string
@@ -223,4 +233,5 @@ export type TEvents = {
     ce_market_types_form: MarketTypesFormAction
     ce_reports_form: ReportsFormAction
     ce_chart_types_form: ChartTypesFormAction
+    ce_tradershub_onboarding_form: TradersHubOnboardingFormAction
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,7 +84,7 @@ type TradersHubOnboardingFormAction = {
     step_num?: number
     step_codename?: string
     account_type: string | null
-    device_type: string
+    device_type?: string
 }
 
 type TradeTypesForm = {


### PR DESCRIPTION
* Add `types` for tradershub tracking events so that we will get type safety and prevent errors on `deriv-app`