### PR TITLE
[CRO] Create remote config for CTA click-through rate tracking, add growthbook utm context for targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,18 +66,18 @@ Analytics?.trackEvent('ce_virtual_signup_form', {
 })
 
 // the same as example below, to not to add repetable properties again and again
-const analyticsData: Parameters<typeof Analytics.trackEvent>[1] = {
+const analytics_data: Parameters<typeof Analytics.trackEvent>[1] = {
     form_name: 'default_diel_deriv',
 }
 Analytics?.trackEvent('ce_virtual_signup_form', {
     action: 'open',
     signup_provider: 'email',
-    ...analyticsData
+    ...analytics_data
 })
 Analytics?.trackEvent('ce_virtual_signup_form', {
     action: 'close',
     signup_provider: 'google',
-    ...analyticsData
+    ...analytics_data
 })
 
 // A/B testing features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deriv-com/analytics",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "description": "The analytics package contains all the utility functions used for tracking user events and sending them to the respective platform such as Rudderstack.",
   "keywords": [
     "rudderstack",

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -11,7 +11,7 @@ type Options = {
 export function createAnalyticsInstance(options?: Options) {
     let _growthbook: Growthbook,
         _rudderstack: RudderStack,
-        coreData: Partial<TCoreAttributes> = {},
+        core_data: Partial<TCoreAttributes> = {},
         cta_buttons: Record<keyof TEvents, boolean> | {} = {},
         offline_cache: any = {}
 
@@ -58,7 +58,7 @@ export function createAnalyticsInstance(options?: Options) {
             })
         }
 
-        coreData = {
+        core_data = {
             ...(user_language !== undefined && { user_language }),
             ...(account_type !== undefined && { account_type }),
             ...(app_id !== undefined && { app_id }),
@@ -84,8 +84,8 @@ export function createAnalyticsInstance(options?: Options) {
     }
 
     const identifyEvent = () => {
-        if (coreData?.user_identity && _rudderstack) {
-            _rudderstack?.identifyEvent(coreData?.user_identity, { language: coreData?.user_language || 'en' })
+        if (core_data?.user_identity && _rudderstack) {
+            _rudderstack?.identifyEvent(core_data?.user_identity, { language: core_data?.user_language || 'en' })
         }
     }
 
@@ -95,7 +95,7 @@ export function createAnalyticsInstance(options?: Options) {
         _rudderstack?.reset()
     }
 
-    const trackEvent = <T extends keyof TEvents>(event: T, analyticsData: TEvents[T]) => {
+    const trackEvent = <T extends keyof TEvents>(event: T, analytics_data: TEvents[T]) => {
         if (!_rudderstack) return
 
         if (navigator.onLine) {
@@ -107,10 +107,10 @@ export function createAnalyticsInstance(options?: Options) {
             }
             if (event in cta_buttons) {
                 // @ts-ignore
-                cta_buttons[event] && _rudderstack?.track(event, { ...coreData, ...analyticsData })
-            } else _rudderstack?.track(event, { ...coreData, ...analyticsData })
+                cta_buttons[event] && _rudderstack?.track(event, { ...core_data, ...analytics_data })
+            } else _rudderstack?.track(event, { ...core_data, ...analytics_data })
         } else {
-            offline_cache[event + analyticsData.action] = { event, payload: { ...coreData, ...analyticsData } }
+            offline_cache[event + analytics_data.action] = { event, payload: { ...core_data, ...analytics_data } }
         }
     }
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -30,6 +30,10 @@ export function createAnalyticsInstance(options?: Options) {
         account_type,
         user_id,
         app_id,
+        utm_source,
+        utm_medium,
+        utm_campaign,
+        is_authorised,
     }: TCoreAttributes) => {
         if (!_growthbook && !_rudderstack) return
 
@@ -43,6 +47,10 @@ export function createAnalyticsInstance(options?: Options) {
                 user_language,
                 device_language,
                 device_type,
+                utm_source,
+                utm_medium,
+                utm_campaign,
+                is_authorised,
             })
         }
 
@@ -89,9 +97,12 @@ export function createAnalyticsInstance(options?: Options) {
 
     const trackEvent = <T extends keyof TEvents>(event: T, analyticsData: TEvents[T]) => {
         if (!_rudderstack) return
-
-        _rudderstack?.track(event, { ...coreData, ...analyticsData })
+        if (navigator?.onLine) {
+            console.log(event, { ...coreData, ...analyticsData })
+            _rudderstack?.track(event, { ...coreData, ...analyticsData })
+        }
     }
+
     const getInstances = () => ({ ab: _growthbook, tracking: _rudderstack })
 
     return {

--- a/src/growthbook.ts
+++ b/src/growthbook.ts
@@ -42,13 +42,27 @@ export class Growthbook {
         return Growthbook._instance
     }
 
-    setAttributes({ id, country, user_language, device_language, device_type }: TGrowthbookAttributes) {
+    setAttributes({
+        id,
+        country,
+        user_language,
+        device_language,
+        device_type,
+        utm_source,
+        utm_medium,
+        utm_campaign,
+        is_authorised,
+    }: TGrowthbookAttributes) {
         return this.GrowthBook.setAttributes({
             id,
             ...(country !== undefined && { country }),
             ...(user_language !== undefined && { user_language }),
             ...(device_language !== undefined && { device_language }),
             ...(device_type !== undefined && { device_type }),
+            ...(utm_source !== undefined && { utm_source }),
+            ...(utm_medium !== undefined && { utm_medium }),
+            ...(utm_campaign !== undefined && { utm_campaign }),
+            ...(is_authorised !== undefined && { is_authorised }),
         })
     }
     getFeatureState<K, V>(id: K) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,10 @@ export type TGrowthbookAttributes = {
     user_language?: string
     device_language?: string
     device_type?: string
+    utm_source?: string
+    utm_medium?: 'ppc-native' | 'affiliate' | 'common' | string
+    utm_campaign?: string
+    is_authorised?: boolean
 }
 export type TCoreAttributes = {
     account_type?: string


### PR DESCRIPTION
As an data analytic, I would like to accumulate clicks on CTA buttons. Also we need possibility to turn-on/off data collecting remotely (without release processes) depends on business needs and Rudderstack limitations 
Also we need to set UTM tags and a part of Targeting groups in Growthbook, to have possibility in future to specify experiments only for users that came from exact acquisition channels, PPC marketing campaigns  