### PR TITLE
fix: resolve CVE-2026-33672 and make identifyEvent traits optional

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,7 +14,6 @@ jobs:
             contents: read
             pull-requests: write
             issues: write
-            id-token: write
             actions: read
 
         # Cancel older runs when new commits arrive on the same PR

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -72,6 +72,7 @@ jobs:
               timeout-minutes: 60
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
                   track_progress: true
                   prompt: |
                       REPO: ${{ github.repository }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@deriv-com/analytics",
-    "version": "1.40.0",
+    "version": "1.40.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@deriv-com/analytics",
-            "version": "1.40.0",
+            "version": "1.40.2",
             "license": "MIT",
             "dependencies": {
                 "@rudderstack/analytics-js": "^3.31.0",
@@ -101,13 +101,6 @@
                 "@csstools/css-tokenizer": "^3.0.3",
                 "lru-cache": "^10.4.3"
             }
-        },
-        "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.0",
@@ -267,7 +260,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "@emnapi/wasi-threads": "1.2.1",
                 "tslib": "^2.4.0"
@@ -280,7 +272,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -292,7 +283,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -792,9 +782,9 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-            "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+            "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -1214,9 +1204,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.122.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-            "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+            "version": "0.124.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+            "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1269,15 +1259,15 @@
             }
         },
         "node_modules/@posthog/core": {
-            "version": "1.24.6",
-            "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.24.6.tgz",
-            "integrity": "sha512-9WkcRKqmXSWIJcca6m3VwA9YbFd4HiG2hKEtDq6FcwEHlvfDhQQUZ5/sJZ47Fw8OtyNMHQ6rW4+COttk4Bg5NQ==",
+            "version": "1.25.2",
+            "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.25.2.tgz",
+            "integrity": "sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==",
             "license": "MIT"
         },
         "node_modules/@posthog/types": {
-            "version": "1.364.7",
-            "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.364.7.tgz",
-            "integrity": "sha512-Rg6q4wSu8krrn8f3Nv44kGXjor4qh5iG0typt2sB7/SYQFRSbXYE2C46+qDMcBYGxmRMsWBitBcZ9x94DQCnfA==",
+            "version": "1.367.0",
+            "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.367.0.tgz",
+            "integrity": "sha512-FUcTEAeKhuHKyCcTQPx/sTN3s8S+PusPsiP8T/LrG/T7pDkwMfNZG0/P630JX6fT6qiW0moVvVSsaXgZDJF7wg==",
             "license": "MIT"
         },
         "node_modules/@protobufjs/aspromise": {
@@ -1345,9 +1335,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-            "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+            "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
             "cpu": [
                 "arm64"
             ],
@@ -1362,9 +1352,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-            "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+            "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
             "cpu": [
                 "arm64"
             ],
@@ -1379,9 +1369,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-            "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+            "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
             "cpu": [
                 "x64"
             ],
@@ -1396,9 +1386,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-            "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+            "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
             "cpu": [
                 "x64"
             ],
@@ -1413,9 +1403,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-            "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+            "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
             "cpu": [
                 "arm"
             ],
@@ -1430,9 +1420,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-            "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+            "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
             "cpu": [
                 "arm64"
             ],
@@ -1450,9 +1440,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-            "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+            "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1470,9 +1460,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-            "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+            "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -1490,9 +1480,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-            "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+            "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
             "cpu": [
                 "s390x"
             ],
@@ -1510,9 +1500,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-            "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+            "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
             "cpu": [
                 "x64"
             ],
@@ -1530,9 +1520,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-            "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+            "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
             "cpu": [
                 "x64"
             ],
@@ -1550,9 +1540,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-            "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+            "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
             "cpu": [
                 "arm64"
             ],
@@ -1567,9 +1557,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-            "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+            "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
             "cpu": [
                 "wasm32"
             ],
@@ -1577,16 +1567,18 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@napi-rs/wasm-runtime": "^1.1.1"
+                "@emnapi/core": "1.9.2",
+                "@emnapi/runtime": "1.9.2",
+                "@napi-rs/wasm-runtime": "^1.1.3"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-            "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+            "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
             "cpu": [
                 "arm64"
             ],
@@ -1601,9 +1593,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-            "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+            "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
             "cpu": [
                 "x64"
             ],
@@ -1618,9 +1610,9 @@
             }
         },
         "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-            "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+            "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
             "dev": true,
             "license": "MIT"
         },
@@ -2526,12 +2518,12 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.5.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-            "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+            "version": "25.6.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+            "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.18.0"
+                "undici-types": "~7.19.0"
             }
         },
         "node_modules/@types/normalize-package-data": {
@@ -2549,16 +2541,16 @@
             "optional": true
         },
         "node_modules/@vitest/expect": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-            "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+            "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.2",
-                "@vitest/utils": "4.1.2",
+                "@vitest/spy": "4.1.4",
+                "@vitest/utils": "4.1.4",
                 "chai": "^6.2.2",
                 "tinyrainbow": "^3.1.0"
             },
@@ -2567,13 +2559,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-            "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+            "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.2",
+                "@vitest/spy": "4.1.4",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -2594,9 +2586,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-            "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+            "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2607,13 +2599,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-            "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+            "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.2",
+                "@vitest/utils": "4.1.4",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -2621,14 +2613,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-            "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+            "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.2",
-                "@vitest/utils": "4.1.2",
+                "@vitest/pretty-format": "4.1.4",
+                "@vitest/utils": "4.1.4",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -2637,9 +2629,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-            "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+            "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -2647,13 +2639,13 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-            "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+            "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.2",
+                "@vitest/pretty-format": "4.1.4",
                 "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.1.0"
             },
@@ -4257,6 +4249,16 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
+        "node_modules/hosted-git-info/node_modules/lru-cache": {
+            "version": "11.3.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+            "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
         "node_modules/html-encoding-sniffer": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -5168,14 +5170,11 @@
             "license": "Apache-2.0"
         },
         "node_modules/lru-cache": {
-            "version": "11.3.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.0.tgz",
-            "integrity": "sha512-sr8xPKE25m6vJVcrdn6NxtC0fVfuPowbscLypegRgOm0yXSqr5JNHCAY3hnusdJ7HRBW04j6Ip4khvHU778DuQ==",
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
             "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
-            }
+            "license": "ISC"
         },
         "node_modules/magic-string": {
             "version": "0.30.21",
@@ -7723,9 +7722,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "version": "8.5.9",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+            "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
             "dev": true,
             "funding": [
                 {
@@ -7795,9 +7794,9 @@
             }
         },
         "node_modules/posthog-js": {
-            "version": "1.364.7",
-            "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.364.7.tgz",
-            "integrity": "sha512-mjYUjim0PSNUjxbGR8MGl7hnbbJMCU+Dy4gRexMRGMRlZT9tskGzsgS4Q6Cvx+63lpkQg5kJrC4bHCuILnQ4/A==",
+            "version": "1.367.0",
+            "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.367.0.tgz",
+            "integrity": "sha512-jWNwB8XjlVUC9PbGaIlmsyohUDMBrwf7cvLuOY3lIOmWVO3L6VxTE3GZShjxpFKQtmWcPxFbf1hcbct1YCb6xg==",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@opentelemetry/api": "^1.9.0",
@@ -7805,8 +7804,8 @@
                 "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
                 "@opentelemetry/resources": "^2.2.0",
                 "@opentelemetry/sdk-logs": "^0.208.0",
-                "@posthog/core": "1.24.6",
-                "@posthog/types": "1.364.7",
+                "@posthog/core": "1.25.2",
+                "@posthog/types": "1.367.0",
                 "core-js": "^3.38.1",
                 "dompurify": "^3.3.2",
                 "fflate": "^0.4.8",
@@ -7826,9 +7825,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-            "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+            "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -7957,13 +7956,6 @@
             "engines": {
                 "node": "^16.14.0 || >=18.0.0"
             }
-        },
-        "node_modules/read-package-up/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/read-package-up/node_modules/normalize-package-data": {
             "version": "6.0.2",
@@ -8166,14 +8158,14 @@
             "license": "MIT"
         },
         "node_modules/rolldown": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-            "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+            "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.122.0",
-                "@rolldown/pluginutils": "1.0.0-rc.12"
+                "@oxc-project/types": "=0.124.0",
+                "@rolldown/pluginutils": "1.0.0-rc.15"
             },
             "bin": {
                 "rolldown": "bin/cli.mjs"
@@ -8182,21 +8174,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-                "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-                "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-                "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+                "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
             }
         },
         "node_modules/rollup": {
@@ -9167,9 +9159,9 @@
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-            "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+            "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9177,14 +9169,14 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -9438,9 +9430,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.18.2",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+            "version": "7.19.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+            "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
             "license": "MIT"
         },
         "node_modules/unicode-emoji-modifier-base": {
@@ -9528,16 +9520,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
-            "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
+            "version": "8.0.8",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+            "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
                 "postcss": "^8.5.8",
-                "rolldown": "1.0.0-rc.12",
+                "rolldown": "1.0.0-rc.15",
                 "tinyglobby": "^0.2.15"
             },
             "bin": {
@@ -9606,19 +9598,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-            "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+            "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.1.2",
-                "@vitest/mocker": "4.1.2",
-                "@vitest/pretty-format": "4.1.2",
-                "@vitest/runner": "4.1.2",
-                "@vitest/snapshot": "4.1.2",
-                "@vitest/spy": "4.1.2",
-                "@vitest/utils": "4.1.2",
+                "@vitest/expect": "4.1.4",
+                "@vitest/mocker": "4.1.4",
+                "@vitest/pretty-format": "4.1.4",
+                "@vitest/runner": "4.1.4",
+                "@vitest/snapshot": "4.1.4",
+                "@vitest/spy": "4.1.4",
+                "@vitest/utils": "4.1.4",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -9646,10 +9638,12 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.2",
-                "@vitest/browser-preview": "4.1.2",
-                "@vitest/browser-webdriverio": "4.1.2",
-                "@vitest/ui": "4.1.2",
+                "@vitest/browser-playwright": "4.1.4",
+                "@vitest/browser-preview": "4.1.4",
+                "@vitest/browser-webdriverio": "4.1.4",
+                "@vitest/coverage-istanbul": "4.1.4",
+                "@vitest/coverage-v8": "4.1.4",
+                "@vitest/ui": "4.1.4",
                 "happy-dom": "*",
                 "jsdom": "*",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -9671,6 +9665,12 @@
                     "optional": true
                 },
                 "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
                     "optional": true
                 },
                 "@vitest/ui": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,13 @@
     "optionalDependencies": {
         "@growthbook/growthbook": "^1.6.5"
     },
+    "overrides": {
+        "npm": {
+            "tinyglobby": {
+                "picomatch": ">=4.0.4"
+            }
+        }
+    },
     "engines": {
         "node": ">=24.13.0",
         "npm": ">=11.7.0"

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -434,7 +434,7 @@ export function createAnalyticsInstance(_options?: Options) {
         }
 
         // Handle PostHog identification independently
-        if (_posthog?.has_initialized && posthogTraits) {
+        if (_posthog?.has_initialized) {
             log('identifyEvent | calling PostHog identify', { user_id: stored_user_id, traits: posthogTraits })
             _posthog.identifyEvent(stored_user_id, posthogTraits as TPosthogIdentifyTraits)
         }

--- a/src/providers/posthog.ts
+++ b/src/providers/posthog.ts
@@ -138,7 +138,7 @@ export class Posthog {
      * @param user_id - The user ID to identify
      * @param traits - User properties (language, country_of_residence, etc.)
      */
-    identifyEvent = (user_id: string, traits: TPosthogIdentifyTraits): void => {
+    identifyEvent = (user_id: string, traits: TPosthogIdentifyTraits = {}): void => {
         if (!this.has_initialized) {
             console.warn('Posthog: Cannot identify - not initialized')
             return


### PR DESCRIPTION
## Summary

- Bump `picomatch` to `>=4.0.4` via npm overrides to resolve CVE-2026-33672
- Make `traits` parameter optional in `identifyEvent` — callers no longer need to pass `{}`

## Changes

### Security fix (CVE-2026-33672)
The vulnerable `picomatch@4.0.3` was nested inside the dev/release toolchain only:
`@semantic-release/npm → npm → tinyglobby → picomatch@4.0.3`

A targeted `overrides` entry in `package.json` forces the safe version without affecting `micromatch`'s unrelated `picomatch@2.x` dependency.

**No production bundle impact.**

### Optional traits in `identifyEvent`
Previously, omitting `traits` caused PostHog identification to be silently skipped due to a falsy guard (`&& posthogTraits`). Users were forced to pass `{}` as a workaround.

**Before:**
```ts
Analytics.identifyEvent(userId, {}) // traits required to avoid silent skip
