### PR TITLE
feat: expose PostHog feature flag API through analytics instance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@deriv-com/analytics",
-    "version": "1.40.2",
+    "version": "1.40.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@deriv-com/analytics",
-            "version": "1.40.2",
+            "version": "1.40.3",
             "license": "MIT",
             "dependencies": {
                 "@rudderstack/analytics-js": "^3.31.0",
                 "js-cookie": "^3.0.5",
-                "posthog-js": "^1.364.0"
+                "posthog-js": "^1.367.0"
             },
             "devDependencies": {
                 "@semantic-release/changelog": "^6.0.3",
@@ -4250,9 +4250,9 @@
             }
         },
         "node_modules/hosted-git-info/node_modules/lru-cache": {
-            "version": "11.3.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-            "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -9420,9 +9420,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-            "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+            "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "dependencies": {
         "@rudderstack/analytics-js": "^3.31.0",
         "js-cookie": "^3.0.5",
-        "posthog-js": "^1.364.0"
+        "posthog-js": "^1.367.0"
     },
     "optionalDependencies": {
         "@growthbook/growthbook": "^1.6.5"

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -560,6 +560,47 @@ export function createAnalyticsInstance(_options?: Options) {
 
     const getInstances = () => ({ ab: _growthbook, tracking: _rudderstack, posthog: _posthog })
 
+    /**
+     * Check whether a PostHog feature flag is enabled for the current user.
+     * Returns undefined if PostHog is not initialized.
+     */
+    const isPosthogFeatureEnabled = (key: string): boolean | undefined => _posthog?.isFeatureEnabled(key)
+
+    /**
+     * Get the value of a PostHog feature flag.
+     * Returns a string variant for multivariate flags, true/false for boolean flags,
+     * or undefined if the flag does not exist or PostHog is not initialized.
+     */
+    const getPosthogFeatureFlag = (key: string): string | boolean | undefined => _posthog?.getFeatureFlag(key)
+
+    /**
+     * Get the JSON payload attached to a PostHog feature flag.
+     * Returns undefined if the flag has no payload or PostHog is not initialized.
+     */
+    const getPosthogFeatureFlagPayload = (key: string): Record<string, any> | undefined =>
+        _posthog?.getFeatureFlagPayload(key)
+
+    /**
+     * Get all currently active PostHog feature flags and their values.
+     * Returns an empty object if PostHog is not initialized.
+     */
+    const getPosthogAllFlags = (): Record<string, string | boolean> => _posthog?.getAllFlags() ?? {}
+
+    /**
+     * Subscribe to PostHog feature flag changes.
+     * The callback fires immediately with current flags and again whenever flags are reloaded.
+     * Returns an unsubscribe function — call it to stop listening.
+     */
+    const onPosthogFeatureFlags = (
+        callback: (flags: string[], variants: Record<string, string | boolean>) => void
+    ): (() => void) => _posthog?.onFeatureFlags(callback) ?? (() => {})
+
+    /**
+     * Force PostHog to reload feature flags from the server.
+     * Useful after attribute/identity changes that may affect flag targeting.
+     */
+    const reloadPosthogFeatureFlags = (): void => _posthog?.reloadFeatureFlags()
+
     const AnalyticsInstance = {
         initialise,
         setAttributes,
@@ -576,6 +617,12 @@ export function createAnalyticsInstance(_options?: Options) {
         getInstances,
         pageView,
         reset,
+        isPosthogFeatureEnabled,
+        getPosthogFeatureFlag,
+        getPosthogFeatureFlagPayload,
+        getPosthogAllFlags,
+        onPosthogFeatureFlags,
+        reloadPosthogFeatureFlags,
     }
 
     if (typeof window !== 'undefined') {

--- a/src/providers/posthog.ts
+++ b/src/providers/posthog.ts
@@ -250,4 +250,117 @@ export class Posthog {
             console.error('Posthog: Failed to capture event', error)
         }
     }
+
+    /**
+     * Check whether a feature flag is enabled for the current user.
+     *
+     * @param key - The feature flag key
+     * @returns true/false, or undefined if PostHog is not ready
+     */
+    isFeatureEnabled = (key: string): boolean | undefined => {
+        if (!this.has_initialized) return undefined
+
+        try {
+            const result = posthog.isFeatureEnabled(key)
+            this.log('isFeatureEnabled', { key, result })
+            return result
+        } catch (error) {
+            console.error('Posthog: Failed to check feature flag', error)
+            return undefined
+        }
+    }
+
+    /**
+     * Get the value of a feature flag.
+     * Returns a string variant for multivariate flags, true/false for boolean flags,
+     * or undefined if the flag does not exist or PostHog is not ready.
+     *
+     * @param key - The feature flag key
+     */
+    getFeatureFlag = (key: string): string | boolean | undefined => {
+        if (!this.has_initialized) return undefined
+
+        try {
+            const result = posthog.getFeatureFlag(key)
+            this.log('getFeatureFlag', { key, result })
+            return result
+        } catch (error) {
+            console.error('Posthog: Failed to get feature flag', error)
+            return undefined
+        }
+    }
+
+    /**
+     * Get the JSON payload associated with a feature flag.
+     * Payloads allow attaching structured metadata (e.g. config objects) to a flag.
+     *
+     * @param key - The feature flag key
+     */
+    getFeatureFlagPayload = (key: string): Record<string, any> | undefined => {
+        if (!this.has_initialized) return undefined
+
+        try {
+            const result = posthog.featureFlags?.getFeatureFlagResult(key)?.payload as Record<string, any> | undefined
+            this.log('getFeatureFlagPayload', { key, result })
+            return result
+        } catch (error) {
+            console.error('Posthog: Failed to get feature flag payload', error)
+            return undefined
+        }
+    }
+
+    /**
+     * Get all currently active feature flags and their values.
+     *
+     * @returns A map of flag key → value (boolean or string variant)
+     */
+    getAllFlags = (): Record<string, string | boolean> => {
+        if (!this.has_initialized) return {}
+
+        try {
+            const result = posthog.featureFlags?.getFlagVariants() ?? {}
+            this.log('getAllFlags', { result })
+            return result
+        } catch (error) {
+            console.error('Posthog: Failed to get all feature flags', error)
+            return {}
+        }
+    }
+
+    /**
+     * Subscribe to feature flag changes.
+     * The callback fires immediately with the current flags and again whenever they are reloaded.
+     *
+     * @param callback - Receives the list of active flag keys and a map of key → variant
+     * @returns An unsubscribe function — call it to stop listening
+     */
+    onFeatureFlags = (
+        callback: (flags: string[], variants: Record<string, string | boolean>) => void
+    ): (() => void) => {
+        if (!this.has_initialized) return () => {}
+
+        try {
+            this.log('onFeatureFlags | subscribing to feature flag changes')
+            const unsubscribe = posthog.onFeatureFlags(callback)
+            return typeof unsubscribe === 'function' ? unsubscribe : () => {}
+        } catch (error) {
+            console.error('Posthog: Failed to subscribe to feature flags', error)
+            return () => {}
+        }
+    }
+
+    /**
+     * Force PostHog to reload feature flags from the server.
+     * Useful after login, logout, or any attribute change that may affect targeting.
+     */
+    reloadFeatureFlags = (): void => {
+        if (!this.has_initialized) return
+
+        try {
+            this.log('reloadFeatureFlags | reloading feature flags')
+            posthog.reloadFeatureFlags()
+        } catch (error) {
+            console.error('Posthog: Failed to reload feature flags', error)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Adds six feature flag methods to the `Posthog` provider class:
  `isFeatureEnabled`, `getFeatureFlag`, `getFeatureFlagPayload`,
  `getAllFlags`, `onFeatureFlags`, and `reloadFeatureFlags`
- Surfaces all six methods on the public `AnalyticsInstance` via
  `createAnalyticsInstance`
- Bumps `posthog-js` dependency from `^1.364.0` to `^1.367.0`

## Test plan

- [ ] Verify `isFeatureEnabled` returns correct boolean for known flags
- [ ] Verify `getFeatureFlag` returns string variant for multivariate flags
- [ ] Verify `getFeatureFlagPayload` returns JSON payload when present
- [ ] Verify `getAllFlags` returns a full map of active flags
- [ ] Verify `onFeatureFlags` callback fires on flag reload; unsubscribe cleans up
- [ ] Verify all methods return safe defaults (`undefined` / `{}` / no-op) when PostHog is not initialized
