### PR TITLE
fix: replace _isIdentified with get_distinct_id for account switch detection

### DIFF
--- a/__tests__/posthog.spec.ts
+++ b/__tests__/posthog.spec.ts
@@ -14,6 +14,14 @@ vi.mock('posthog-js', () => ({
         _isIdentified: vi.fn(),
         get_property: vi.fn(),
         setPersonProperties: vi.fn(),
+        isFeatureEnabled: vi.fn(),
+        getFeatureFlag: vi.fn(),
+        getFeatureFlagResult: vi.fn(),
+        onFeatureFlags: vi.fn(),
+        reloadFeatureFlags: vi.fn(),
+        featureFlags: {
+            getFlagVariants: vi.fn(),
+        },
     },
 }))
 
@@ -40,6 +48,12 @@ describe('PostHog Provider', () => {
         ;(posthog.get_distinct_id as Mock).mockClear()
         ;(posthog.get_property as Mock).mockClear()
         ;(posthog.setPersonProperties as Mock).mockClear()
+        ;(posthog.isFeatureEnabled as Mock).mockClear()
+        ;(posthog.getFeatureFlag as Mock).mockClear()
+        ;(posthog.getFeatureFlagResult as Mock).mockClear()
+        ;(posthog.onFeatureFlags as Mock).mockClear()
+        ;(posthog.reloadFeatureFlags as Mock).mockClear()
+        ;(posthog.featureFlags.getFlagVariants as Mock).mockClear()
 
         // Ensure _isIdentified is properly mocked
         if (typeof posthog._isIdentified !== 'function') {
@@ -219,44 +233,41 @@ describe('PostHog Provider', () => {
         })
 
         test('should identify user when not previously identified', () => {
-            ;(posthog._isIdentified as Mock).mockReturnValue(false)
+            instance.has_identified = false
 
             instance.identifyEvent('CR123', { is_internal: false })
 
             expect(posthog.identify).toHaveBeenCalledWith('CR123', { client_id: 'CR123', is_internal: false })
         })
 
-        test('should not identify when user is already identified', () => {
-            ;(posthog._isIdentified as Mock).mockReturnValue(true)
+        test('should not identify when already identified as the same user', () => {
+            instance.has_identified = true
+            ;(posthog.get_distinct_id as Mock).mockReturnValue('CR123')
 
             instance.identifyEvent('CR123', { is_internal: false })
 
             expect(posthog.identify).not.toHaveBeenCalled()
-            // setPersonProperties is not called here — use backfillPersonProperties for backfilling
             expect(posthog.setPersonProperties).not.toHaveBeenCalled()
         })
 
+        test('should re-identify when a different user logs in after account switch', () => {
+            // Simulate: user A was identified, then logged out (reset called),
+            // but stale distinct_id from localStorage is still account A's id
+            instance.has_identified = true
+            ;(posthog.get_distinct_id as Mock).mockReturnValue('CR111') // stale distinct_id
+
+            instance.identifyEvent('CR222', { is_internal: false }) // new user
+
+            expect(posthog.identify).toHaveBeenCalledWith('CR222', { client_id: 'CR222', is_internal: false })
+            expect(instance.has_identified).toBe(true)
+        })
+
         test('should identify user and include client_id in traits', () => {
-            ;(posthog._isIdentified as Mock).mockReturnValue(false)
+            instance.has_identified = false
 
             instance.identifyEvent('CR123', { is_internal: false })
 
             expect(posthog.identify).toHaveBeenCalledWith('CR123', { client_id: 'CR123', is_internal: false })
-        })
-
-        test('should handle missing _isIdentified function gracefully', () => {
-            const original_isIdentified = posthog._isIdentified
-            // @ts-ignore - testing runtime scenario
-            posthog._isIdentified = undefined
-
-            instance.identifyEvent('CR789', { is_internal: false })
-
-            // Should use instance has_identified flag (false by default)
-            expect(posthog.alias).not.toHaveBeenCalled()
-            expect(posthog.identify).toHaveBeenCalledWith('CR789', { client_id: 'CR789', is_internal: false })
-
-            // Restore
-            posthog._isIdentified = original_isIdentified
         })
 
         test('should warn when not initialized', () => {
@@ -509,13 +520,245 @@ describe('PostHog Provider', () => {
         })
     })
 
+    describe('Feature Flags', () => {
+        let instance: Posthog
+
+        beforeEach(async () => {
+            instance = new Posthog({ apiKey: 'test-key' })
+            await instance.init()
+        })
+
+        describe('isFeatureEnabled', () => {
+            test('should return true when flag is enabled', () => {
+                ;(posthog.isFeatureEnabled as Mock).mockReturnValue(true)
+
+                expect(instance.isFeatureEnabled('my-flag')).toBe(true)
+                expect(posthog.isFeatureEnabled).toHaveBeenCalledWith('my-flag')
+            })
+
+            test('should return false when flag is disabled', () => {
+                ;(posthog.isFeatureEnabled as Mock).mockReturnValue(false)
+
+                expect(instance.isFeatureEnabled('my-flag')).toBe(false)
+            })
+
+            test('should return undefined when not initialized', () => {
+                const uninitializedInstance = new Posthog({ apiKey: '' })
+
+                expect(uninitializedInstance.isFeatureEnabled('my-flag')).toBeUndefined()
+                expect(posthog.isFeatureEnabled).not.toHaveBeenCalled()
+            })
+
+            test('should handle errors gracefully', () => {
+                ;(posthog.isFeatureEnabled as Mock).mockImplementationOnce(() => {
+                    throw new Error('isFeatureEnabled failed')
+                })
+
+                expect(instance.isFeatureEnabled('my-flag')).toBeUndefined()
+                expect(consoleErrorSpy).toHaveBeenCalledWith('Posthog: Failed to check feature flag', expect.any(Error))
+            })
+        })
+
+        describe('getFeatureFlag', () => {
+            test('should return string variant for multivariate flag', () => {
+                ;(posthog.getFeatureFlag as Mock).mockReturnValue('variant-a')
+
+                expect(instance.getFeatureFlag('my-flag')).toBe('variant-a')
+                expect(posthog.getFeatureFlag).toHaveBeenCalledWith('my-flag')
+            })
+
+            test('should return true for enabled boolean flag', () => {
+                ;(posthog.getFeatureFlag as Mock).mockReturnValue(true)
+
+                expect(instance.getFeatureFlag('my-flag')).toBe(true)
+            })
+
+            test('should return undefined when flag does not exist', () => {
+                ;(posthog.getFeatureFlag as Mock).mockReturnValue(undefined)
+
+                expect(instance.getFeatureFlag('nonexistent')).toBeUndefined()
+            })
+
+            test('should return undefined when not initialized', () => {
+                const uninitializedInstance = new Posthog({ apiKey: '' })
+
+                expect(uninitializedInstance.getFeatureFlag('my-flag')).toBeUndefined()
+                expect(posthog.getFeatureFlag).not.toHaveBeenCalled()
+            })
+
+            test('should handle errors gracefully', () => {
+                ;(posthog.getFeatureFlag as Mock).mockImplementationOnce(() => {
+                    throw new Error('getFeatureFlag failed')
+                })
+
+                expect(instance.getFeatureFlag('my-flag')).toBeUndefined()
+                expect(consoleErrorSpy).toHaveBeenCalledWith('Posthog: Failed to get feature flag', expect.any(Error))
+            })
+        })
+
+        describe('getFeatureFlagPayload', () => {
+            test('should return object payload', () => {
+                ;(posthog.getFeatureFlagResult as Mock).mockReturnValue({ payload: { color: 'blue' } })
+
+                expect(instance.getFeatureFlagPayload('my-flag')).toEqual({ color: 'blue' })
+                expect(posthog.getFeatureFlagResult).toHaveBeenCalledWith('my-flag')
+            })
+
+            test('should return string payload', () => {
+                ;(posthog.getFeatureFlagResult as Mock).mockReturnValue({ payload: 'control' })
+
+                expect(instance.getFeatureFlagPayload('my-flag')).toBe('control')
+            })
+
+            test('should return number payload', () => {
+                ;(posthog.getFeatureFlagResult as Mock).mockReturnValue({ payload: 42 })
+
+                expect(instance.getFeatureFlagPayload('my-flag')).toBe(42)
+            })
+
+            test('should return undefined when flag has no payload', () => {
+                ;(posthog.getFeatureFlagResult as Mock).mockReturnValue(undefined)
+
+                expect(instance.getFeatureFlagPayload('my-flag')).toBeUndefined()
+            })
+
+            test('should return undefined when not initialized', () => {
+                const uninitializedInstance = new Posthog({ apiKey: '' })
+
+                expect(uninitializedInstance.getFeatureFlagPayload('my-flag')).toBeUndefined()
+                expect(posthog.getFeatureFlagResult).not.toHaveBeenCalled()
+            })
+
+            test('should handle errors gracefully', () => {
+                ;(posthog.getFeatureFlagResult as Mock).mockImplementationOnce(() => {
+                    throw new Error('getFeatureFlagResult failed')
+                })
+
+                expect(instance.getFeatureFlagPayload('my-flag')).toBeUndefined()
+                expect(consoleErrorSpy).toHaveBeenCalledWith(
+                    'Posthog: Failed to get feature flag payload',
+                    expect.any(Error)
+                )
+            })
+        })
+
+        describe('getAllFlags', () => {
+            test('should return map of flag key to value', () => {
+                ;(posthog.featureFlags.getFlagVariants as Mock).mockReturnValue({
+                    'flag-a': true,
+                    'flag-b': 'variant-x',
+                })
+
+                expect(instance.getAllFlags()).toEqual({ 'flag-a': true, 'flag-b': 'variant-x' })
+            })
+
+            test('should return empty object when no flags are active', () => {
+                ;(posthog.featureFlags.getFlagVariants as Mock).mockReturnValue({})
+
+                expect(instance.getAllFlags()).toEqual({})
+            })
+
+            test('should return empty object when not initialized', () => {
+                const uninitializedInstance = new Posthog({ apiKey: '' })
+
+                expect(uninitializedInstance.getAllFlags()).toEqual({})
+                expect(posthog.featureFlags.getFlagVariants).not.toHaveBeenCalled()
+            })
+
+            test('should handle errors gracefully', () => {
+                ;(posthog.featureFlags.getFlagVariants as Mock).mockImplementationOnce(() => {
+                    throw new Error('getFlagVariants failed')
+                })
+
+                expect(instance.getAllFlags()).toEqual({})
+                expect(consoleErrorSpy).toHaveBeenCalledWith(
+                    'Posthog: Failed to get all feature flags',
+                    expect.any(Error)
+                )
+            })
+        })
+
+        describe('onFeatureFlags', () => {
+            test('should subscribe and return unsubscribe function', () => {
+                const unsubscribe = vi.fn()
+                ;(posthog.onFeatureFlags as Mock).mockReturnValue(unsubscribe)
+                const callback = vi.fn()
+
+                const result = instance.onFeatureFlags(callback)
+
+                expect(posthog.onFeatureFlags).toHaveBeenCalledWith(callback)
+                expect(result).toBe(unsubscribe)
+            })
+
+            test('should return no-op when posthog.onFeatureFlags returns non-function', () => {
+                ;(posthog.onFeatureFlags as Mock).mockReturnValue(undefined)
+
+                const result = instance.onFeatureFlags(vi.fn())
+
+                expect(typeof result).toBe('function')
+                expect(() => result()).not.toThrow()
+            })
+
+            test('should return no-op when not initialized', () => {
+                const uninitializedInstance = new Posthog({ apiKey: '' })
+
+                const result = uninitializedInstance.onFeatureFlags(vi.fn())
+
+                expect(posthog.onFeatureFlags).not.toHaveBeenCalled()
+                expect(typeof result).toBe('function')
+            })
+
+            test('should handle errors gracefully', () => {
+                ;(posthog.onFeatureFlags as Mock).mockImplementationOnce(() => {
+                    throw new Error('onFeatureFlags failed')
+                })
+
+                const result = instance.onFeatureFlags(vi.fn())
+
+                expect(result).toBeDefined()
+                expect(consoleErrorSpy).toHaveBeenCalledWith(
+                    'Posthog: Failed to subscribe to feature flags',
+                    expect.any(Error)
+                )
+            })
+        })
+
+        describe('reloadFeatureFlags', () => {
+            test('should call posthog.reloadFeatureFlags', () => {
+                instance.reloadFeatureFlags()
+
+                expect(posthog.reloadFeatureFlags).toHaveBeenCalledTimes(1)
+            })
+
+            test('should be a no-op when not initialized', () => {
+                const uninitializedInstance = new Posthog({ apiKey: '' })
+
+                uninitializedInstance.reloadFeatureFlags()
+
+                expect(posthog.reloadFeatureFlags).not.toHaveBeenCalled()
+            })
+
+            test('should handle errors gracefully', () => {
+                ;(posthog.reloadFeatureFlags as Mock).mockImplementationOnce(() => {
+                    throw new Error('reloadFeatureFlags failed')
+                })
+
+                expect(() => instance.reloadFeatureFlags()).not.toThrow()
+                expect(consoleErrorSpy).toHaveBeenCalledWith(
+                    'Posthog: Failed to reload feature flags',
+                    expect.any(Error)
+                )
+            })
+        })
+    })
+
     describe('Integration Tests', () => {
         test('should handle full user lifecycle', async () => {
             ;(posthog.init as Mock).mockClear()
             ;(posthog.identify as Mock).mockClear()
             ;(posthog.capture as Mock).mockClear()
             ;(posthog.reset as Mock).mockClear()
-            ;(posthog._isIdentified as Mock) = vi.fn().mockReturnValue(false)
+            ;(posthog.get_distinct_id as Mock).mockReturnValue('anon-id')
 
             const instance = new Posthog({ apiKey: 'test-key' })
             await instance.init()
@@ -549,7 +792,7 @@ describe('PostHog Provider', () => {
 
         test('should handle multiple identify calls correctly', async () => {
             ;(posthog.identify as Mock).mockClear()
-            ;(posthog._isIdentified as Mock) = vi.fn().mockReturnValue(false)
+            ;(posthog.get_distinct_id as Mock).mockReturnValue('anon-id')
 
             const instance = new Posthog({ apiKey: 'test-key' })
             await instance.init()
@@ -560,13 +803,41 @@ describe('PostHog Provider', () => {
             expect(posthog.identify).toHaveBeenCalledTimes(1)
             expect(instance.has_identified).toBe(true)
 
-            // Second identify - should not call identify again
-            ;(posthog._isIdentified as Mock).mockReturnValue(true)
+            // Second identify for same user — should not call identify again
+            ;(posthog.get_distinct_id as Mock).mockReturnValue('CR100')
 
             instance.identifyEvent('CR100', { email: 'user@example.com', language: 'es' })
 
             expect(posthog.alias).not.toHaveBeenCalled()
             expect(posthog.identify).toHaveBeenCalledTimes(1) // Still only 1 call
+        })
+
+        test('should re-identify after logout and login with a different account', async () => {
+            ;(posthog.identify as Mock).mockClear()
+            ;(posthog.reset as Mock).mockClear()
+            ;(posthog.get_distinct_id as Mock).mockReturnValue('anon-id')
+
+            const instance = new Posthog({ apiKey: 'test-key' })
+            await instance.init()
+
+            // User A logs in
+            instance.identifyEvent('CR111', { is_internal: false })
+            expect(posthog.identify).toHaveBeenCalledWith('CR111', { client_id: 'CR111', is_internal: false })
+            expect(instance.has_identified).toBe(true)
+
+            // User A logs out — reset clears has_identified
+            instance.reset()
+            expect(instance.has_identified).toBe(false)
+
+            // Simulate stale localStorage: distinct_id is still CR111
+            ;(posthog.get_distinct_id as Mock).mockReturnValue('CR111')
+
+            // User B logs in — must re-identify even though distinct_id !== CR222
+            instance.has_identified = true // simulate race where flag was not cleared
+            instance.identifyEvent('CR222', { is_internal: false })
+
+            expect(posthog.identify).toHaveBeenCalledWith('CR222', { client_id: 'CR222', is_internal: false })
+            expect(posthog.identify).toHaveBeenCalledTimes(2)
         })
     })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@deriv-com/analytics",
-    "version": "1.40.3",
+    "version": "1.41.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@deriv-com/analytics",
-            "version": "1.40.3",
+            "version": "1.41.0",
             "license": "MIT",
             "dependencies": {
                 "@rudderstack/analytics-js": "^3.31.0",
                 "js-cookie": "^3.0.5",
-                "posthog-js": "^1.367.0"
+                "posthog-js": "^1.369.0"
             },
             "devDependencies": {
                 "@semantic-release/changelog": "^6.0.3",
@@ -22,9 +22,9 @@
                 "@types/js-cookie": "^3.0.6",
                 "@types/node": "^25.5.2",
                 "husky": "^9.1.7",
-                "jsdom": "^26.1.0",
+                "jsdom": "^29.0.2",
                 "lint-staged": "^16.4.0",
-                "prettier": "^3.8.1",
+                "prettier": "^3.8.3",
                 "semantic-release": "^25.0.3",
                 "tslib": "^2.8.1",
                 "tsup": "^8.5.1",
@@ -72,9 +72,9 @@
             }
         },
         "node_modules/@actions/http-client/node_modules/undici": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-            "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+            "version": "6.25.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+            "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -89,18 +89,43 @@
             "license": "MIT"
         },
         "node_modules/@asamuzakjp/css-color": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-            "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+            "version": "5.1.10",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
+            "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@csstools/css-calc": "^2.1.3",
-                "@csstools/css-color-parser": "^3.0.9",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "lru-cache": "^10.4.3"
+                "@csstools/css-calc": "^3.1.1",
+                "@csstools/css-color-parser": "^4.0.2",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
+        },
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "7.0.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
+            "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/nwsapi": "^2.3.9",
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.2.1",
+                "is-potential-custom-element-name": "^1.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/nwsapi": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.0",
@@ -127,6 +152,19 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@bramus/specificity": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "^3.0.0"
+            },
+            "bin": {
+                "specificity": "bin/cli.js"
+            }
+        },
         "node_modules/@colors/colors": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -139,9 +177,9 @@
             }
         },
         "node_modules/@csstools/color-helpers": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-            "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+            "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
             "dev": true,
             "funding": [
                 {
@@ -155,13 +193,13 @@
             ],
             "license": "MIT-0",
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
             }
         },
         "node_modules/@csstools/css-calc": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-            "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+            "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
             "dev": true,
             "funding": [
                 {
@@ -175,17 +213,17 @@
             ],
             "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
             },
             "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.5",
-                "@csstools/css-tokenizer": "^3.0.4"
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
             }
         },
         "node_modules/@csstools/css-color-parser": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-            "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+            "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
             "dev": true,
             "funding": [
                 {
@@ -199,21 +237,21 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@csstools/color-helpers": "^5.1.0",
-                "@csstools/css-calc": "^2.1.4"
+                "@csstools/color-helpers": "^6.0.2",
+                "@csstools/css-calc": "^3.2.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
             },
             "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.5",
-                "@csstools/css-tokenizer": "^3.0.4"
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
             }
         },
         "node_modules/@csstools/css-parser-algorithms": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-            "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
             "dev": true,
             "funding": [
                 {
@@ -227,16 +265,41 @@
             ],
             "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
             },
             "peerDependencies": {
-                "@csstools/css-tokenizer": "^3.0.4"
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+            "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "peerDependencies": {
+                "css-tree": "^3.2.1"
+            },
+            "peerDependenciesMeta": {
+                "css-tree": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@csstools/css-tokenizer": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-            "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
             "dev": true,
             "funding": [
                 {
@@ -250,7 +313,7 @@
             ],
             "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
             }
         },
         "node_modules/@emnapi/core": {
@@ -727,6 +790,24 @@
             ],
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@exodus/bytes": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+            "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@noble/hashes": "^1.8.0 || ^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@noble/hashes": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@growthbook/growthbook": {
@@ -1265,9 +1346,9 @@
             "license": "MIT"
         },
         "node_modules/@posthog/types": {
-            "version": "1.367.0",
-            "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.367.0.tgz",
-            "integrity": "sha512-FUcTEAeKhuHKyCcTQPx/sTN3s8S+PusPsiP8T/LrG/T7pDkwMfNZG0/P630JX6fT6qiW0moVvVSsaXgZDJF7wg==",
+            "version": "1.369.0",
+            "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.369.0.tgz",
+            "integrity": "sha512-iFkLrg/+QRQHc8KSjO9parN6H3rftM2ld2sCJ/GeBRRO9MJYCdc6jXSFRgF7aGJPzb79syqksz+CrnBzdZnBKg==",
             "license": "MIT"
         },
         "node_modules/@protobufjs/aspromise": {
@@ -2777,6 +2858,16 @@
             "dev": true,
             "license": "Apache-2.0"
         },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
+            }
+        },
         "node_modules/bottleneck": {
             "version": "2.19.5",
             "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
@@ -3462,32 +3553,32 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/cssstyle": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
-            "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+        "node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@asamuzakjp/css-color": "^3.2.0",
-                "rrweb-cssom": "^0.8.0"
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
             }
         },
         "node_modules/data-urls": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "whatwg-mimetype": "^4.0.0",
-                "whatwg-url": "^14.0.0"
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "node_modules/debug": {
@@ -3559,9 +3650,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-            "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+            "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -4249,27 +4340,17 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/hosted-git-info/node_modules/lru-cache": {
-            "version": "11.3.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
         "node_modules/html-encoding-sniffer": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "whatwg-encoding": "^3.1.1"
+                "@exodus/bytes": "^1.6.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "node_modules/http-proxy-agent": {
@@ -4324,19 +4405,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/typicode"
-            }
-        },
-        "node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/import-fresh": {
@@ -4615,35 +4683,36 @@
             }
         },
         "node_modules/jsdom": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-            "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+            "version": "29.0.2",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+            "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "cssstyle": "^4.2.1",
-                "data-urls": "^5.0.0",
-                "decimal.js": "^10.5.0",
-                "html-encoding-sniffer": "^4.0.0",
-                "http-proxy-agent": "^7.0.2",
-                "https-proxy-agent": "^7.0.6",
+                "@asamuzakjp/css-color": "^5.1.5",
+                "@asamuzakjp/dom-selector": "^7.0.6",
+                "@bramus/specificity": "^2.4.2",
+                "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+                "@exodus/bytes": "^1.15.0",
+                "css-tree": "^3.2.1",
+                "data-urls": "^7.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^6.0.0",
                 "is-potential-custom-element-name": "^1.0.1",
-                "nwsapi": "^2.2.16",
-                "parse5": "^7.2.1",
-                "rrweb-cssom": "^0.8.0",
+                "lru-cache": "^11.2.7",
+                "parse5": "^8.0.0",
                 "saxes": "^6.0.0",
                 "symbol-tree": "^3.2.4",
-                "tough-cookie": "^5.1.1",
+                "tough-cookie": "^6.0.1",
+                "undici": "^7.24.5",
                 "w3c-xmlserializer": "^5.0.0",
-                "webidl-conversions": "^7.0.0",
-                "whatwg-encoding": "^3.1.1",
-                "whatwg-mimetype": "^4.0.0",
-                "whatwg-url": "^14.1.1",
-                "ws": "^8.18.0",
+                "webidl-conversions": "^8.0.1",
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.1",
                 "xml-name-validator": "^5.0.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
             },
             "peerDependencies": {
                 "canvas": "^3.0.0"
@@ -5170,11 +5239,14 @@
             "license": "Apache-2.0"
         },
         "node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
             "dev": true,
-            "license": "ISC"
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
         },
         "node_modules/magic-string": {
             "version": "0.30.21",
@@ -5238,6 +5310,13 @@
             "peerDependencies": {
                 "marked": ">=1 <16"
             }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/meow": {
             "version": "13.2.0",
@@ -7373,13 +7452,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/nwsapi": {
-            "version": "2.2.23",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-            "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7589,9 +7661,9 @@
             }
         },
         "node_modules/parse5": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+            "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7794,9 +7866,9 @@
             }
         },
         "node_modules/posthog-js": {
-            "version": "1.367.0",
-            "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.367.0.tgz",
-            "integrity": "sha512-jWNwB8XjlVUC9PbGaIlmsyohUDMBrwf7cvLuOY3lIOmWVO3L6VxTE3GZShjxpFKQtmWcPxFbf1hcbct1YCb6xg==",
+            "version": "1.369.0",
+            "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.369.0.tgz",
+            "integrity": "sha512-fOJzwpCb/TWxJBsUNKJ5PhHNl0+X7zRrVTuUrIH+EfsIfxJGSkOa0lWPJJGr3xzg810JHCUpuhn5sFBBxfHqIQ==",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@opentelemetry/api": "^1.9.0",
@@ -7805,7 +7877,7 @@
                 "@opentelemetry/resources": "^2.2.0",
                 "@opentelemetry/sdk-logs": "^0.208.0",
                 "@posthog/core": "1.25.2",
-                "@posthog/types": "1.367.0",
+                "@posthog/types": "1.369.0",
                 "core-js": "^3.38.1",
                 "dompurify": "^3.3.2",
                 "fflate": "^0.4.8",
@@ -7825,9 +7897,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
-            "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -7871,9 +7943,9 @@
             "license": "ISC"
         },
         "node_modules/protobufjs": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-            "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+            "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -7956,6 +8028,13 @@
             "engines": {
                 "node": "^16.14.0 || >=18.0.0"
             }
+        },
+        "node_modules/read-package-up/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/read-package-up/node_modules/normalize-package-data": {
             "version": "6.0.2",
@@ -8088,6 +8167,16 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8236,24 +8325,10 @@
                 "fsevents": "~2.3.2"
             }
         },
-        "node_modules/rrweb-cssom": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-            "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true,
             "license": "MIT"
         },
@@ -9196,22 +9271,22 @@
             }
         },
         "node_modules/tldts": {
-            "version": "6.1.86",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-            "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+            "version": "7.0.28",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+            "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tldts-core": "^6.1.86"
+                "tldts-core": "^7.0.28"
             },
             "bin": {
                 "tldts": "bin/cli.js"
             }
         },
         "node_modules/tldts-core": {
-            "version": "6.1.86",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-            "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+            "version": "7.0.28",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+            "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -9229,29 +9304,29 @@
             }
         },
         "node_modules/tough-cookie": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-            "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+            "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "tldts": "^6.1.32"
+                "tldts": "^7.0.5"
             },
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/tr46": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "punycode": "^2.3.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/traverse": {
@@ -9420,9 +9495,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "7.24.8",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-            "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+            "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9714,51 +9789,38 @@
             "license": "Apache-2.0"
         },
         "node_modules/webidl-conversions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/whatwg-encoding": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "iconv-lite": "0.6.3"
-            },
-            "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/whatwg-mimetype": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/whatwg-url": {
-            "version": "14.2.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tr46": "^5.1.0",
-                "webidl-conversions": "^7.0.0"
+                "@exodus/bytes": "^1.11.0",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "node_modules/which": {
@@ -9842,28 +9904,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/ws": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -63,9 +63,9 @@
         "@types/js-cookie": "^3.0.6",
         "@types/node": "^25.5.2",
         "husky": "^9.1.7",
-        "jsdom": "^26.1.0",
+        "jsdom": "^29.0.2",
         "lint-staged": "^16.4.0",
-        "prettier": "^3.8.1",
+        "prettier": "^3.8.3",
         "semantic-release": "^25.0.3",
         "tslib": "^2.8.1",
         "tsup": "^8.5.1",
@@ -75,7 +75,7 @@
     "dependencies": {
         "@rudderstack/analytics-js": "^3.31.0",
         "js-cookie": "^3.0.5",
-        "posthog-js": "^1.367.0"
+        "posthog-js": "^1.369.0"
     },
     "optionalDependencies": {
         "@growthbook/growthbook": "^1.6.5"
@@ -83,7 +83,7 @@
     "overrides": {
         "npm": {
             "tinyglobby": {
-                "picomatch": ">=4.0.4"
+                "picomatch": "4.0.4"
             }
         }
     },

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -577,7 +577,9 @@ export function createAnalyticsInstance(_options?: Options) {
      * Get the JSON payload attached to a PostHog feature flag.
      * Returns undefined if the flag has no payload or PostHog is not initialized.
      */
-    const getPosthogFeatureFlagPayload = (key: string): Record<string, any> | undefined =>
+    const getPosthogFeatureFlagPayload = (
+        key: string
+    ): string | number | boolean | null | Record<string, unknown> | unknown[] | undefined =>
         _posthog?.getFeatureFlagPayload(key)
 
     /**

--- a/src/providers/posthog.ts
+++ b/src/providers/posthog.ts
@@ -326,7 +326,7 @@ export class Posthog {
         if (!this.has_initialized) return {}
 
         try {
-            const result = posthog.featureFlags.getFlagVariants() ?? {}
+            const result = posthog.featureFlags?.getFlagVariants() ?? {}
             this.log('getAllFlags', { result })
             return result
         } catch (error) {

--- a/src/providers/posthog.ts
+++ b/src/providers/posthog.ts
@@ -145,10 +145,9 @@ export class Posthog {
         }
 
         try {
-            const isIdentified =
-                typeof posthog._isIdentified === 'function' ? posthog._isIdentified() : this.has_identified
+            const alreadyThisUser = this.has_identified && posthog.get_distinct_id() === user_id
 
-            if (user_id && !isIdentified) {
+            if (user_id && !alreadyThisUser) {
                 this.log('identifyEvent | identifying user', { user_id, traits })
                 posthog.identify(user_id, {
                     ...traits,
@@ -296,11 +295,20 @@ export class Posthog {
      *
      * @param key - The feature flag key
      */
-    getFeatureFlagPayload = (key: string): Record<string, any> | undefined => {
+    getFeatureFlagPayload = (
+        key: string
+    ): string | number | boolean | null | Record<string, unknown> | unknown[] | undefined => {
         if (!this.has_initialized) return undefined
 
         try {
-            const result = posthog.featureFlags?.getFeatureFlagResult(key)?.payload as Record<string, any> | undefined
+            const result = posthog.getFeatureFlagResult(key)?.payload as
+                | string
+                | number
+                | boolean
+                | null
+                | Record<string, unknown>
+                | unknown[]
+                | undefined
             this.log('getFeatureFlagPayload', { key, result })
             return result
         } catch (error) {
@@ -318,7 +326,7 @@ export class Posthog {
         if (!this.has_initialized) return {}
 
         try {
-            const result = posthog.featureFlags?.getFlagVariants() ?? {}
+            const result = posthog.featureFlags.getFlagVariants() ?? {}
             this.log('getAllFlags', { result })
             return result
         } catch (error) {


### PR DESCRIPTION
## Summary
- `identifyEvent` previously relied on `posthog._isIdentified()` which does not reset
  on logout, so a different user logging in would silently skip re-identification.
  Now compares `get_distinct_id()` against the incoming `user_id` — if they differ,
  identify is always called regardless of `has_identified`.
- `getFeatureFlagPayload` now calls `posthog.getFeatureFlagResult` directly instead of
  routing through the optional `featureFlags` accessor; `getAllFlags` removes stale
  optional chaining on the same property.
- Tightened return type of `getFeatureFlagPayload` from `Record<string, any>` to a
  proper JSON-value union.

## Test plan
- [ ] All existing PostHog unit tests pass
- [ ] New `Feature Flags` describe block covers `isFeatureEnabled`, `getFeatureFlag`,
      `getFeatureFlagPayload`, `getAllFlags`, `onFeatureFlags`, `reloadFeatureFlags`
      (happy path, uninitialised guard, error handling)
- [ ] New integration test covers full logout → re-login with a different account
- [ ] `identifyEvent` account-switch test verifies stale `distinct_id` does not block
      re-identification

🤖 Generated with [Claude Code](https://claude.com/claude-code)