### PR TITLE
feat: set maskAllInputs as default for PostHog session recording

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@deriv-com/analytics",
-    "version": "1.41.0",
+    "version": "1.41.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@deriv-com/analytics",
-            "version": "1.41.0",
+            "version": "1.41.1",
             "license": "MIT",
             "dependencies": {
                 "@rudderstack/analytics-js": "^3.31.0",
                 "js-cookie": "^3.0.5",
-                "posthog-js": "^1.369.0"
+                "posthog-js": "^1.372.9"
             },
             "devDependencies": {
                 "@semantic-release/changelog": "^6.0.3",
@@ -40,9 +40,9 @@
             }
         },
         "node_modules/@actions/core": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
-            "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+            "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -61,9 +61,9 @@
             }
         },
         "node_modules/@actions/http-client": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
-            "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+            "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -89,14 +89,15 @@
             "license": "MIT"
         },
         "node_modules/@asamuzakjp/css-color": {
-            "version": "5.1.10",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
-            "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@csstools/css-calc": "^3.1.1",
-                "@csstools/css-color-parser": "^4.0.2",
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@csstools/css-calc": "^3.2.0",
+                "@csstools/css-color-parser": "^4.1.0",
                 "@csstools/css-parser-algorithms": "^4.0.0",
                 "@csstools/css-tokenizer": "^4.0.0"
             },
@@ -105,17 +106,28 @@
             }
         },
         "node_modules/@asamuzakjp/dom-selector": {
-            "version": "7.0.9",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
-            "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+            "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
                 "@asamuzakjp/nwsapi": "^2.3.9",
                 "bidi-js": "^1.0.3",
                 "css-tree": "^3.2.1",
                 "is-potential-custom-element-name": "^1.0.1"
             },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/generational-cache": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+            "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
@@ -317,9 +329,9 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-            "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -329,9 +341,9 @@
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -863,9 +875,9 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-            "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -1147,12 +1159,12 @@
             }
         },
         "node_modules/@opentelemetry/resources": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
-            "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+            "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "2.6.1",
+                "@opentelemetry/core": "2.7.1",
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
@@ -1163,9 +1175,9 @@
             }
         },
         "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
-            "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+            "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -1285,9 +1297,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.124.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-            "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+            "version": "0.128.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
+            "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1340,15 +1352,18 @@
             }
         },
         "node_modules/@posthog/core": {
-            "version": "1.25.2",
-            "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.25.2.tgz",
-            "integrity": "sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==",
-            "license": "MIT"
+            "version": "1.28.3",
+            "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.28.3.tgz",
+            "integrity": "sha512-SOy0aphKawZzp8jxfeOpTcXPwi6ii0I2V6tX8YXnM+WbxKKR/R+BXLK0jS6LV8kZtW3H5YxmPAfuIbUP1UnGTw==",
+            "license": "MIT",
+            "dependencies": {
+                "@posthog/types": "1.372.9"
+            }
         },
         "node_modules/@posthog/types": {
-            "version": "1.369.0",
-            "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.369.0.tgz",
-            "integrity": "sha512-iFkLrg/+QRQHc8KSjO9parN6H3rftM2ld2sCJ/GeBRRO9MJYCdc6jXSFRgF7aGJPzb79syqksz+CrnBzdZnBKg==",
+            "version": "1.372.9",
+            "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.9.tgz",
+            "integrity": "sha512-B7k9S+H9WUKHXxe1HOkQWbpWtMcrBvsodm5stZaLQ3pYxf9TowtwssdzTtX4hHjzSYqgrS1IpNnJX4vs1KgBzA==",
             "license": "MIT"
         },
         "node_modules/@protobufjs/aspromise": {
@@ -1364,9 +1379,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/codegen": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+            "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
@@ -1392,9 +1407,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/inquire": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+            "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -1410,15 +1425,15 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/utf8": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+            "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-            "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
+            "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1433,9 +1448,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-            "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
+            "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1450,9 +1465,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-            "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
+            "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
             "cpu": [
                 "x64"
             ],
@@ -1467,9 +1482,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-            "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
+            "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
             "cpu": [
                 "x64"
             ],
@@ -1484,9 +1499,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-            "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
+            "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
             "cpu": [
                 "arm"
             ],
@@ -1501,9 +1516,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-            "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
+            "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1521,9 +1536,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-            "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
+            "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
             "cpu": [
                 "arm64"
             ],
@@ -1541,9 +1556,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-            "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
+            "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
             "cpu": [
                 "ppc64"
             ],
@@ -1561,9 +1576,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-            "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
+            "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
             "cpu": [
                 "s390x"
             ],
@@ -1581,9 +1596,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-            "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
+            "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
             "cpu": [
                 "x64"
             ],
@@ -1601,9 +1616,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-            "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
+            "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
             "cpu": [
                 "x64"
             ],
@@ -1621,9 +1636,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-            "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
+            "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
             "cpu": [
                 "arm64"
             ],
@@ -1638,9 +1653,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-            "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
+            "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
             "cpu": [
                 "wasm32"
             ],
@@ -1648,18 +1663,18 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "1.9.2",
-                "@emnapi/runtime": "1.9.2",
-                "@napi-rs/wasm-runtime": "^1.1.3"
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-            "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
+            "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1674,9 +1689,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-            "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
+            "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
             "cpu": [
                 "x64"
             ],
@@ -1691,16 +1706,16 @@
             }
         },
         "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-            "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
+            "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-            "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+            "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
             "cpu": [
                 "arm"
             ],
@@ -1712,9 +1727,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-            "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+            "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
             "cpu": [
                 "arm64"
             ],
@@ -1726,9 +1741,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-            "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+            "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
             "cpu": [
                 "arm64"
             ],
@@ -1740,9 +1755,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-            "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+            "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
             "cpu": [
                 "x64"
             ],
@@ -1754,9 +1769,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-            "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+            "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1768,9 +1783,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-            "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+            "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
             "cpu": [
                 "x64"
             ],
@@ -1782,9 +1797,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-            "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+            "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
             "cpu": [
                 "arm"
             ],
@@ -1799,9 +1814,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-            "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+            "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
             "cpu": [
                 "arm"
             ],
@@ -1816,9 +1831,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-            "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+            "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
             "cpu": [
                 "arm64"
             ],
@@ -1833,9 +1848,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-            "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+            "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
             "cpu": [
                 "arm64"
             ],
@@ -1850,9 +1865,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-            "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+            "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
             "cpu": [
                 "loong64"
             ],
@@ -1867,9 +1882,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-            "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+            "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
             "cpu": [
                 "loong64"
             ],
@@ -1884,9 +1899,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-            "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+            "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -1901,9 +1916,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-            "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+            "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
             "cpu": [
                 "ppc64"
             ],
@@ -1918,9 +1933,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-            "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+            "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
             "cpu": [
                 "riscv64"
             ],
@@ -1935,9 +1950,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-            "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+            "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -1952,9 +1967,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-            "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+            "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
             "cpu": [
                 "s390x"
             ],
@@ -1969,9 +1984,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-            "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+            "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
             "cpu": [
                 "x64"
             ],
@@ -1986,9 +2001,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-            "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+            "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
             "cpu": [
                 "x64"
             ],
@@ -2003,9 +2018,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-            "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+            "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
             "cpu": [
                 "x64"
             ],
@@ -2017,9 +2032,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-            "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+            "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
             "cpu": [
                 "arm64"
             ],
@@ -2031,9 +2046,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-            "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+            "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
             "cpu": [
                 "arm64"
             ],
@@ -2045,9 +2060,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-            "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+            "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
             "cpu": [
                 "ia32"
             ],
@@ -2059,9 +2074,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-            "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+            "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
             "cpu": [
                 "x64"
             ],
@@ -2073,9 +2088,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-            "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+            "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
             "cpu": [
                 "x64"
             ],
@@ -2087,9 +2102,9 @@
             ]
         },
         "node_modules/@rudderstack/analytics-js": {
-            "version": "3.31.0",
-            "resolved": "https://registry.npmjs.org/@rudderstack/analytics-js/-/analytics-js-3.31.0.tgz",
-            "integrity": "sha512-ylMile9f75wTepb01F514MrRIe+wXS9VdVoF0m1z+BFXfB6UKdAUZ7noxUdy5XQssSS/bEfh3RZ0qVmxyMxNOA==",
+            "version": "3.31.1",
+            "resolved": "https://registry.npmjs.org/@rudderstack/analytics-js/-/analytics-js-3.31.1.tgz",
+            "integrity": "sha512-pc0ecQWwTLatYx26GBz6wjPUmYxRH9DhDGLM5euw5YOX7J67mchpHs0VpF+NfbGFh2js4eHi9pwUn44YVCEtgA==",
             "license": "Elastic-2.0"
         },
         "node_modules/@sec-ant/readable-stream": {
@@ -2556,9 +2571,9 @@
             "license": "MIT"
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -2622,16 +2637,16 @@
             "optional": true
         },
         "node_modules/@vitest/expect": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-            "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+            "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.4",
-                "@vitest/utils": "4.1.4",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
                 "chai": "^6.2.2",
                 "tinyrainbow": "^3.1.0"
             },
@@ -2640,13 +2655,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-            "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+            "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.4",
+                "@vitest/spy": "4.1.5",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -2667,9 +2682,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-            "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+            "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2680,13 +2695,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-            "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+            "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.4",
+                "@vitest/utils": "4.1.5",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -2694,14 +2709,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-            "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+            "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.4",
-                "@vitest/utils": "4.1.4",
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/utils": "4.1.5",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -2710,9 +2725,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-            "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+            "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -2720,13 +2735,13 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-            "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+            "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.4",
+                "@vitest/pretty-format": "4.1.5",
                 "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.1.0"
             },
@@ -3650,9 +3665,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-            "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+            "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -3696,13 +3711,13 @@
             "license": "MIT"
         },
         "node_modules/entities": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
-                "node": ">=0.12"
+                "node": ">=20.19.0"
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
@@ -3900,9 +3915,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-            "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -4172,9 +4187,9 @@
             }
         },
         "node_modules/fs-extra": {
-            "version": "11.3.4",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-            "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+            "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4328,9 +4343,9 @@
             }
         },
         "node_modules/hosted-git-info": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-            "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4617,9 +4632,9 @@
             "license": "ISC"
         },
         "node_modules/issue-parser": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.1.tgz",
-            "integrity": "sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.2.tgz",
+            "integrity": "sha512-7atWPjhGEIX3JEtMrOYd8TKzboYlq+5sNbdl9POiLYOI14G5HZiQbZP0Xj5EZdrufQVXfJlpTV0hys0CuxwxZw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4683,28 +4698,28 @@
             }
         },
         "node_modules/jsdom": {
-            "version": "29.0.2",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
-            "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+            "version": "29.1.1",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+            "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@asamuzakjp/css-color": "^5.1.5",
-                "@asamuzakjp/dom-selector": "^7.0.6",
+                "@asamuzakjp/css-color": "^5.1.11",
+                "@asamuzakjp/dom-selector": "^7.1.1",
                 "@bramus/specificity": "^2.4.2",
-                "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+                "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
                 "@exodus/bytes": "^1.15.0",
                 "css-tree": "^3.2.1",
                 "data-urls": "^7.0.0",
                 "decimal.js": "^10.6.0",
                 "html-encoding-sniffer": "^6.0.0",
                 "is-potential-custom-element-name": "^1.0.1",
-                "lru-cache": "^11.2.7",
-                "parse5": "^8.0.0",
+                "lru-cache": "^11.3.5",
+                "parse5": "^8.0.1",
                 "saxes": "^6.0.0",
                 "symbol-tree": "^3.2.4",
                 "tough-cookie": "^6.0.1",
-                "undici": "^7.24.5",
+                "undici": "^7.25.0",
                 "w3c-xmlserializer": "^5.0.0",
                 "webidl-conversions": "^8.0.1",
                 "whatwg-mimetype": "^5.0.0",
@@ -4745,9 +4760,9 @@
             "license": "MIT"
         },
         "node_modules/jsonfile": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-            "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5239,9 +5254,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/lru-cache": {
-            "version": "11.3.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+            "version": "11.3.6",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+            "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -5447,9 +5462,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "dev": true,
             "funding": [
                 {
@@ -5524,9 +5539,9 @@
             }
         },
         "node_modules/npm": {
-            "version": "11.12.1",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-11.12.1.tgz",
-            "integrity": "sha512-zcoUuF1kezGSAo0CqtvoLXX3mkRqzuqYdL6Y5tdo8g69NVV3CkjQ6ZBhBgB4d7vGkPcV6TcvLi3GRKPDFX+xTA==",
+            "version": "11.14.0",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-11.14.0.tgz",
+            "integrity": "sha512-6jfZzqK8EfWGnTeZQe+bgMx4IgiEZn7k1eM4GE8SE81B3iYch52dVSMO1hC2OnNbFLIwzvwUkUxsOOcUPG2XIw==",
             "bundleDependencies": [
                 "@isaacs/string-locale-compare",
                 "@npmcli/arborist",
@@ -5605,8 +5620,8 @@
             ],
             "dependencies": {
                 "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/arborist": "^9.4.2",
-                "@npmcli/config": "^10.8.1",
+                "@npmcli/arborist": "^9.5.0",
+                "@npmcli/config": "^10.9.0",
                 "@npmcli/fs": "^5.0.0",
                 "@npmcli/map-workspaces": "^5.0.3",
                 "@npmcli/metavuln-calculator": "^9.0.3",
@@ -5627,24 +5642,24 @@
                 "hosted-git-info": "^9.0.2",
                 "ini": "^6.0.0",
                 "init-package-json": "^8.2.5",
-                "is-cidr": "^6.0.3",
+                "is-cidr": "^6.0.4",
                 "json-parse-even-better-errors": "^5.0.0",
                 "libnpmaccess": "^10.0.3",
-                "libnpmdiff": "^8.1.5",
-                "libnpmexec": "^10.2.5",
-                "libnpmfund": "^7.0.19",
+                "libnpmdiff": "^8.1.7",
+                "libnpmexec": "^10.2.7",
+                "libnpmfund": "^7.0.21",
                 "libnpmorg": "^8.0.1",
-                "libnpmpack": "^9.1.5",
+                "libnpmpack": "^9.1.7",
                 "libnpmpublish": "^11.1.3",
                 "libnpmsearch": "^9.0.1",
                 "libnpmteam": "^8.0.2",
                 "libnpmversion": "^8.0.3",
                 "make-fetch-happen": "^15.0.5",
-                "minimatch": "^10.2.4",
+                "minimatch": "^10.2.5",
                 "minipass": "^7.1.3",
                 "minipass-pipeline": "^1.2.4",
                 "ms": "^2.1.2",
-                "node-gyp": "^12.2.0",
+                "node-gyp": "^12.3.0",
                 "nopt": "^9.0.0",
                 "npm-audit-report": "^7.0.0",
                 "npm-install-checks": "^8.0.0",
@@ -5663,7 +5678,7 @@
                 "spdx-expression-parse": "^4.0.0",
                 "ssri": "^13.0.1",
                 "supports-color": "^10.2.2",
-                "tar": "^7.5.11",
+                "tar": "^7.5.13",
                 "text-table": "~0.2.0",
                 "tiny-relative-date": "^2.0.2",
                 "treeverse": "^3.0.0",
@@ -5735,7 +5750,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/arborist": {
-            "version": "9.4.2",
+            "version": "9.5.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -5783,7 +5798,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/config": {
-            "version": "10.8.1",
+            "version": "10.9.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -5986,7 +6001,7 @@
             }
         },
         "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-            "version": "0.5.0",
+            "version": "0.5.1",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
@@ -6128,7 +6143,7 @@
             }
         },
         "node_modules/npm/node_modules/brace-expansion": {
-            "version": "5.0.4",
+            "version": "5.0.5",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -6197,7 +6212,7 @@
             }
         },
         "node_modules/npm/node_modules/cidr-regex": {
-            "version": "5.0.3",
+            "version": "5.0.5",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
@@ -6253,7 +6268,7 @@
             }
         },
         "node_modules/npm/node_modules/diff": {
-            "version": "8.0.3",
+            "version": "8.0.4",
             "dev": true,
             "inBundle": true,
             "license": "BSD-3-Clause",
@@ -6420,7 +6435,7 @@
             }
         },
         "node_modules/npm/node_modules/ip-address": {
-            "version": "10.1.0",
+            "version": "10.1.1",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -6429,12 +6444,12 @@
             }
         },
         "node_modules/npm/node_modules/is-cidr": {
-            "version": "6.0.3",
+            "version": "6.0.4",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "cidr-regex": "^5.0.1"
+                "cidr-regex": "^5.0.4"
             },
             "engines": {
                 "node": ">=20"
@@ -6502,12 +6517,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmdiff": {
-            "version": "8.1.5",
+            "version": "8.1.7",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^9.4.2",
+                "@npmcli/arborist": "^9.5.0",
                 "@npmcli/installed-package-contents": "^4.0.0",
                 "binary-extensions": "^3.0.0",
                 "diff": "^8.0.2",
@@ -6521,13 +6536,13 @@
             }
         },
         "node_modules/npm/node_modules/libnpmexec": {
-            "version": "10.2.5",
+            "version": "10.2.7",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.0",
-                "@npmcli/arborist": "^9.4.2",
+                "@npmcli/arborist": "^9.5.0",
                 "@npmcli/package-json": "^7.0.0",
                 "@npmcli/run-script": "^10.0.0",
                 "ci-info": "^4.0.0",
@@ -6544,12 +6559,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmfund": {
-            "version": "7.0.19",
+            "version": "7.0.21",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^9.4.2"
+                "@npmcli/arborist": "^9.5.0"
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -6569,12 +6584,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmpack": {
-            "version": "9.1.5",
+            "version": "9.1.7",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^9.4.2",
+                "@npmcli/arborist": "^9.5.0",
                 "@npmcli/run-script": "^10.0.0",
                 "npm-package-arg": "^13.0.0",
                 "pacote": "^21.0.2"
@@ -6644,7 +6659,7 @@
             }
         },
         "node_modules/npm/node_modules/lru-cache": {
-            "version": "11.2.7",
+            "version": "11.3.5",
             "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
@@ -6676,12 +6691,12 @@
             }
         },
         "node_modules/npm/node_modules/minimatch": {
-            "version": "10.2.4",
+            "version": "10.2.5",
             "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -6729,34 +6744,16 @@
             }
         },
         "node_modules/npm/node_modules/minipass-flush": {
-            "version": "1.0.5",
+            "version": "1.0.6",
             "dev": true,
             "inBundle": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "minipass": "^3.0.0"
+                "minipass": "^7.1.3"
             },
             "engines": {
-                "node": ">= 8"
+                "node": ">=16 || 14 >=14.17"
             }
-        },
-        "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-            "version": "3.3.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-            "version": "4.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
         },
         "node_modules/npm/node_modules/minipass-pipeline": {
             "version": "1.2.4",
@@ -6837,7 +6834,7 @@
             }
         },
         "node_modules/npm/node_modules/node-gyp": {
-            "version": "12.2.0",
+            "version": "12.3.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -6845,12 +6842,12 @@
                 "env-paths": "^2.2.0",
                 "exponential-backoff": "^3.1.1",
                 "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^15.0.0",
                 "nopt": "^9.0.0",
                 "proc-log": "^6.0.0",
                 "semver": "^7.3.5",
                 "tar": "^7.5.4",
                 "tinyglobby": "^0.2.12",
+                "undici": "^6.25.0",
                 "which": "^6.0.0"
             },
             "bin": {
@@ -7223,12 +7220,12 @@
             }
         },
         "node_modules/npm/node_modules/socks": {
-            "version": "2.8.7",
+            "version": "2.8.8",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "ip-address": "^10.0.1",
+                "ip-address": "^10.1.1",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
@@ -7297,7 +7294,7 @@
             }
         },
         "node_modules/npm/node_modules/tar": {
-            "version": "7.5.11",
+            "version": "7.5.13",
             "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
@@ -7325,13 +7322,13 @@
             "license": "MIT"
         },
         "node_modules/npm/node_modules/tinyglobby": {
-            "version": "0.2.15",
+            "version": "0.2.16",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -7358,7 +7355,7 @@
             }
         },
         "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
+            "version": "4.0.4",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -7390,6 +7387,15 @@
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/undici": {
+            "version": "6.25.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
             }
         },
         "node_modules/npm/node_modules/util-deprecate": {
@@ -7661,13 +7667,13 @@
             }
         },
         "node_modules/parse5": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-            "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "entities": "^6.0.0"
+                "entities": "^8.0.0"
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -7794,9 +7800,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.9",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-            "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
             "dev": true,
             "funding": [
                 {
@@ -7866,9 +7872,9 @@
             }
         },
         "node_modules/posthog-js": {
-            "version": "1.369.0",
-            "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.369.0.tgz",
-            "integrity": "sha512-fOJzwpCb/TWxJBsUNKJ5PhHNl0+X7zRrVTuUrIH+EfsIfxJGSkOa0lWPJJGr3xzg810JHCUpuhn5sFBBxfHqIQ==",
+            "version": "1.372.9",
+            "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.372.9.tgz",
+            "integrity": "sha512-qFhTxxrONCO4YBubuEp6/f3beRPku8OqgfHwpSro/XcDU0oPXMVyvsXGUnxhjaq4PvQb79PwvquAX0/HIGcnWg==",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@opentelemetry/api": "^1.9.0",
@@ -7876,8 +7882,8 @@
                 "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
                 "@opentelemetry/resources": "^2.2.0",
                 "@opentelemetry/sdk-logs": "^0.208.0",
-                "@posthog/core": "1.25.2",
-                "@posthog/types": "1.369.0",
+                "@posthog/core": "1.28.3",
+                "@posthog/types": "1.372.9",
                 "core-js": "^3.38.1",
                 "dompurify": "^3.3.2",
                 "fflate": "^0.4.8",
@@ -7943,22 +7949,22 @@
             "license": "ISC"
         },
         "node_modules/protobufjs": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-            "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+            "version": "7.5.6",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+            "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
-                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/codegen": "^2.0.5",
                 "@protobufjs/eventemitter": "^1.1.0",
                 "@protobufjs/fetch": "^1.1.0",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/inquire": "^1.1.1",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
-                "@protobufjs/utf8": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.1",
                 "@types/node": ">=13.7.0",
                 "long": "^5.0.0"
             },
@@ -8105,9 +8111,9 @@
             }
         },
         "node_modules/read-pkg/node_modules/type-fest": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-            "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+            "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "dependencies": {
@@ -8247,14 +8253,14 @@
             "license": "MIT"
         },
         "node_modules/rolldown": {
-            "version": "1.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-            "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+            "version": "1.0.0-rc.18",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
+            "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.124.0",
-                "@rolldown/pluginutils": "1.0.0-rc.15"
+                "@oxc-project/types": "=0.128.0",
+                "@rolldown/pluginutils": "1.0.0-rc.18"
             },
             "bin": {
                 "rolldown": "bin/cli.mjs"
@@ -8263,27 +8269,27 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-                "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-                "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-                "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+                "@rolldown/binding-android-arm64": "1.0.0-rc.18",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
             }
         },
         "node_modules/rollup": {
-            "version": "4.60.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-            "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+            "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8297,31 +8303,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.60.1",
-                "@rollup/rollup-android-arm64": "4.60.1",
-                "@rollup/rollup-darwin-arm64": "4.60.1",
-                "@rollup/rollup-darwin-x64": "4.60.1",
-                "@rollup/rollup-freebsd-arm64": "4.60.1",
-                "@rollup/rollup-freebsd-x64": "4.60.1",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-                "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-                "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-                "@rollup/rollup-linux-arm64-musl": "4.60.1",
-                "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-                "@rollup/rollup-linux-loong64-musl": "4.60.1",
-                "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-                "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-                "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-                "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-                "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-                "@rollup/rollup-linux-x64-gnu": "4.60.1",
-                "@rollup/rollup-linux-x64-musl": "4.60.1",
-                "@rollup/rollup-openbsd-x64": "4.60.1",
-                "@rollup/rollup-openharmony-arm64": "4.60.1",
-                "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-                "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-                "@rollup/rollup-win32-x64-gnu": "4.60.1",
-                "@rollup/rollup-win32-x64-msvc": "4.60.1",
+                "@rollup/rollup-android-arm-eabi": "4.60.3",
+                "@rollup/rollup-android-arm64": "4.60.3",
+                "@rollup/rollup-darwin-arm64": "4.60.3",
+                "@rollup/rollup-darwin-x64": "4.60.3",
+                "@rollup/rollup-freebsd-arm64": "4.60.3",
+                "@rollup/rollup-freebsd-x64": "4.60.3",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+                "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+                "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+                "@rollup/rollup-linux-arm64-musl": "4.60.3",
+                "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+                "@rollup/rollup-linux-loong64-musl": "4.60.3",
+                "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+                "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+                "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+                "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+                "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+                "@rollup/rollup-linux-x64-gnu": "4.60.3",
+                "@rollup/rollup-linux-x64-musl": "4.60.3",
+                "@rollup/rollup-openbsd-x64": "4.60.3",
+                "@rollup/rollup-openharmony-arm64": "4.60.3",
+                "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+                "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+                "@rollup/rollup-win32-x64-gnu": "4.60.3",
+                "@rollup/rollup-win32-x64-msvc": "4.60.3",
                 "fsevents": "~2.3.2"
             }
         },
@@ -8612,9 +8618,9 @@
             }
         },
         "node_modules/semantic-release/node_modules/type-fest": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-            "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+            "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "dependencies": {
@@ -8920,9 +8926,9 @@
             "license": "MIT"
         },
         "node_modules/std-env": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-            "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -8958,9 +8964,9 @@
             }
         },
         "node_modules/string-width": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-            "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9234,9 +9240,9 @@
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-            "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+            "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9271,22 +9277,22 @@
             }
         },
         "node_modules/tldts": {
-            "version": "7.0.28",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
-            "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+            "version": "7.0.30",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+            "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tldts-core": "^7.0.28"
+                "tldts-core": "^7.0.30"
             },
             "bin": {
                 "tldts": "bin/cli.js"
             }
         },
         "node_modules/tldts-core": {
-            "version": "7.0.28",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
-            "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+            "version": "7.0.30",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+            "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -9460,9 +9466,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-            "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -9474,9 +9480,9 @@
             }
         },
         "node_modules/ufo": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-            "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+            "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
             "dev": true,
             "license": "MIT"
         },
@@ -9595,17 +9601,17 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.8",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-            "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+            "version": "8.0.11",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
+            "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
-                "postcss": "^8.5.8",
-                "rolldown": "1.0.0-rc.15",
-                "tinyglobby": "^0.2.15"
+                "postcss": "^8.5.14",
+                "rolldown": "1.0.0-rc.18",
+                "tinyglobby": "^0.2.16"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -9621,7 +9627,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.0",
+                "@vitejs/devtools": "^0.1.18",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -9673,19 +9679,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-            "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+            "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.1.4",
-                "@vitest/mocker": "4.1.4",
-                "@vitest/pretty-format": "4.1.4",
-                "@vitest/runner": "4.1.4",
-                "@vitest/snapshot": "4.1.4",
-                "@vitest/spy": "4.1.4",
-                "@vitest/utils": "4.1.4",
+                "@vitest/expect": "4.1.5",
+                "@vitest/mocker": "4.1.5",
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/runner": "4.1.5",
+                "@vitest/snapshot": "4.1.5",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -9713,12 +9719,12 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.4",
-                "@vitest/browser-preview": "4.1.4",
-                "@vitest/browser-webdriverio": "4.1.4",
-                "@vitest/coverage-istanbul": "4.1.4",
-                "@vitest/coverage-v8": "4.1.4",
-                "@vitest/ui": "4.1.4",
+                "@vitest/browser-playwright": "4.1.5",
+                "@vitest/browser-preview": "4.1.5",
+                "@vitest/browser-webdriverio": "4.1.5",
+                "@vitest/coverage-istanbul": "4.1.5",
+                "@vitest/coverage-v8": "4.1.5",
+                "@vitest/ui": "4.1.5",
                 "happy-dom": "*",
                 "jsdom": "*",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -9944,9 +9950,9 @@
             }
         },
         "node_modules/yaml": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+            "version": "2.8.4",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+            "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
             "dev": true,
             "license": "ISC",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "dependencies": {
         "@rudderstack/analytics-js": "^3.31.0",
         "js-cookie": "^3.0.5",
-        "posthog-js": "^1.369.0"
+        "posthog-js": "^1.372.9"
     },
     "optionalDependencies": {
         "@growthbook/growthbook": "^1.6.5"

--- a/src/providers/posthog.ts
+++ b/src/providers/posthog.ts
@@ -104,6 +104,7 @@ export class Posthog {
                 session_recording: {
                     recordCrossOriginIframes: true,
                     minimumDurationMilliseconds: 30000,
+                    maskAllInputs: true,
                     ...config.session_recording,
                 },
                 before_send: event => {


### PR DESCRIPTION
## Summary
- Sets `maskAllInputs: true` as a hardcoded default in the PostHog `session_recording` config
- Applies to all PostHog projects initialized through this library
- Consumers can still override this by passing `maskAllInputs: false` in their `config.session_recording`

## Test plan
- [ ] Verify session recordings no longer capture input field values
- [ ] Verify consumers can still override with `maskAllInputs: false` if needed
